### PR TITLE
Harden portable dotfiles setup

### DIFF
--- a/.bin/debian/setup-dependencies
+++ b/.bin/debian/setup-dependencies
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]] || [[ ! -r /etc/os-release ]] ||
+  ! grep -Eq '^ID="?debian"?$|^ID_LIKE="?([^" ]+ )*debian( [^" ]+)*"?$' /etc/os-release; then
+  echo "This dependency installer only supports Debian-based Linux." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=.bin/lib/github-keys.sh
+source "$SCRIPT_DIR/../lib/github-keys.sh"
+
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  sudo_cmd=()
+else
+  command -v sudo >/dev/null 2>&1 || {
+    echo "sudo is required to install Debian packages." >&2
+    exit 1
+  }
+  sudo_cmd=(sudo)
+fi
+
+command -v apt-get >/dev/null 2>&1 || {
+  echo "Missing dependency: apt-get" >&2
+  exit 1
+}
+
+packages=(
+  bash-completion bat bsdextrautils build-essential ca-certificates curl ffmpeg fzf git jq
+  neovim openssh-client pandoc python3-pygments qrencode rsync shellcheck tmux
+  unzip zsh zsh-autosuggestions zsh-syntax-highlighting
+)
+
+"${sudo_cmd[@]}" apt-get update
+
+# These packages are present in newer Debian releases but not every supported one.
+for package in eza gh golang-go starship; do
+  if apt-cache show "$package" >/dev/null 2>&1; then
+    packages+=("$package")
+  fi
+done
+
+"${sudo_cmd[@]}" apt-get install --no-install-recommends "${packages[@]}"
+
+# Debian historically installed bat as batcat. Provide the name used by this repo
+# without replacing an existing user-managed command.
+if ! command -v bat >/dev/null 2>&1 && command -v batcat >/dev/null 2>&1; then
+  mkdir -p "$HOME/.local/bin"
+  if [[ ! -e "$HOME/.local/bin/bat" && ! -L "$HOME/.local/bin/bat" ]]; then
+    ln -s "$(command -v batcat)" "$HOME/.local/bin/bat"
+    echo "Linked ~/.local/bin/bat to $(command -v batcat)."
+  fi
+fi
+
+read -rp "Would you like to replace authorized_keys with your GitHub public keys? [y/N]: " setup_keys
+if [[ "$setup_keys" =~ ^[Yy]$ ]]; then
+  read -rp "Enter your GitHub username: " github_username
+  fetch_github_keys "$github_username" "$HOME/.ssh/authorized_keys"
+  echo "Authorized keys updated with mode 0600."
+fi
+
+if [[ ! -d "$HOME/.oh-my-zsh" ]]; then
+  git clone --depth 1 https://github.com/ohmyzsh/ohmyzsh.git "$HOME/.oh-my-zsh"
+  echo "Oh My Zsh installed."
+fi
+
+echo "Dependency setup complete. Run 'exec zsh' to reload your shell."

--- a/.bin/lib/github-keys.sh
+++ b/.bin/lib/github-keys.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Shared helpers for safely downloading public SSH keys from GitHub.
+
+validate_github_username() {
+  local username="$1"
+
+  [[ "$username" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,38}$ ]] &&
+    [[ "$username" != *--* ]] &&
+    [[ "$username" != *- ]]
+}
+
+fetch_github_keys() {
+  local username="$1"
+  local destination="$2"
+  local principal="${3:-}"
+  local raw_file
+  local output_file
+
+  if ! validate_github_username "$username"; then
+    echo "Invalid GitHub username: $username" >&2
+    return 2
+  fi
+
+  if [[ -n "$principal" && ( "$principal" =~ [[:space:]] || "$principal" == *","* ) ]]; then
+    echo "Invalid allowed-signers principal: $principal" >&2
+    return 2
+  fi
+
+  command -v curl >/dev/null 2>&1 || {
+    echo "Missing dependency: curl" >&2
+    return 1
+  }
+
+  mkdir -p "$(dirname "$destination")"
+  chmod 700 "$(dirname "$destination")"
+
+  raw_file="$(mktemp "${destination}.raw.XXXXXX")"
+  output_file="$(mktemp "${destination}.new.XXXXXX")"
+
+  if ! curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+    --location --max-time 30 "https://github.com/${username}.keys" >"$raw_file"; then
+    rm -f "$raw_file" "$output_file"
+    return 1
+  fi
+
+  if [[ ! -s "$raw_file" ]] || ! awk '
+    NF >= 2 && $1 ~ /^(ssh-(ed25519|rsa)|ecdsa-sha2-nistp(256|384|521)|sk-(ssh-ed25519|ecdsa-sha2-nistp256)@openssh.com)$/ { next }
+    { exit 1 }
+  ' "$raw_file"; then
+    echo "GitHub returned no valid public SSH keys for $username" >&2
+    rm -f "$raw_file" "$output_file"
+    return 1
+  fi
+
+  if [[ -n "$principal" ]]; then
+    awk -v principal="$principal" '{ print principal, $0 }' "$raw_file" >"$output_file"
+  else
+    cp "$raw_file" "$output_file"
+  fi
+
+  chmod 600 "$output_file"
+  mv -f "$output_file" "$destination"
+  rm -f "$raw_file"
+}

--- a/.bin/macos/doc-pdf
+++ b/.bin/macos/doc-pdf
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: docx2pdf file.docx [another.docx ...]
+command -v pandoc >/dev/null 2>&1 || {
+	echo "Missing dependency: pandoc" >&2
+	exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+	echo "usage: $(basename "$0") <document> [document ...]" >&2
+	exit 2
+fi
+
 for f in "$@"; do
 	[[ -f "$f" ]] || {
 		echo "Not a file: $f" >&2

--- a/.bin/macos/export-1pass-env.sh
+++ b/.bin/macos/export-1pass-env.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 
 usage() {
   cat <<'USAGE'
@@ -25,14 +26,17 @@ out=".env"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --item|-i)
+      [[ $# -ge 2 && -n "$2" ]] || { echo "Missing value for $1" >&2; exit 2; }
       item="${2:-}"
       shift 2
       ;;
     --vault|-v)
+      [[ $# -ge 2 && -n "$2" ]] || { echo "Missing value for $1" >&2; exit 2; }
       vault="${2:-}"
       shift 2
       ;;
     --out|-o)
+      [[ $# -ge 2 && -n "$2" ]] || { echo "Missing value for $1" >&2; exit 2; }
       out="${2:-}"
       shift 2
       ;;
@@ -69,7 +73,13 @@ if [[ -n "$vault" ]]; then
   op_args+=(--vault "$vault")
 fi
 
-tmp="$(mktemp "${TMPDIR:-/tmp}/1pass-env.XXXXXX")"
+out_dir="$(dirname "$out")"
+if [[ ! -d "$out_dir" || -d "$out" ]]; then
+  echo "Output directory does not exist or output is a directory: $out" >&2
+  exit 2
+fi
+
+tmp="$(mktemp "$out_dir/.1pass-env.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 
 op "${op_args[@]}" |
@@ -80,18 +90,21 @@ op "${op_args[@]}" |
       | gsub("^_+|_+$"; "")
       | if test("^[0-9]") then "OP_" + . else . end;
 
-    .fields
-    | map(select(.value != null and (.value | tostring | length > 0)))
-    | map({
+    [.fields[]
+    | select(.value != null and (.value | tostring | length > 0))
+    | {
         key: ((.label // .id) | tostring | env_key),
         value: (.value | tostring)
-      })
-    | unique_by(.key)
-    | sort_by(.key)
-    | .[]
+      }]
+    | if length != (unique_by(.key) | length)
+      then error("duplicate environment keys after normalization")
+      else .
+      end
+    | sort_by(.key)[]
     | "\(.key)=\(.value | @sh)"
   ' > "$tmp"
 
+chmod 600 "$tmp"
 mv "$tmp" "$out"
 trap - EXIT
 

--- a/.bin/macos/mdnote
+++ b/.bin/macos/mdnote
@@ -1,27 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Check if pandoc is installed
-if ! command -v pandoc &>/dev/null; then
-	echo "Pandoc is not installed. Please install it first."
-	exit 1
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "mdnote requires macOS." >&2
+  exit 1
 fi
 
-# Get the clipboard content
-clipboard_content=$(pbpaste)
+for command_name in osascript pandoc pbpaste; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing dependency: $command_name" >&2
+    exit 1
+  }
+done
 
-# Convert the clipboard content from Markdown to HTML using Pandoc
-html_content=$(echo "$clipboard_content" | pandoc -f markdown -t html)
+html_content="$(pbpaste | pandoc -f markdown -t html)"
 
-# Escape double quotes in the HTML content
-escaped_html_content=$(echo "$html_content" | sed 's/"/\\"/g')
-
-# Create an AppleScript to add the HTML content to a new note
-osascript <<EOF
-tell application "Notes"
-    tell account "iCloud" -- Change this to the desired account if needed
-        make new note at folder "Notes" with properties {name:"Imported Note", body:"$escaped_html_content"}
+# Pass the generated HTML as argv instead of interpolating it into AppleScript.
+osascript - "$html_content" <<'APPLESCRIPT'
+on run argv
+  tell application "Notes"
+    tell account "iCloud"
+      make new note at folder "Notes" with properties {name:"Imported Note", body:(item 1 of argv)}
     end tell
-end tell
-EOF
+  end tell
+end run
+APPLESCRIPT
 
-echo "Markdown content from clipboard has been converted and added to a new Apple Note."
+echo "Markdown clipboard content was added to a new Apple Note."

--- a/.bin/macos/setup-dependencies
+++ b/.bin/macos/setup-dependencies
@@ -1,48 +1,88 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# brew setup
-if [ -x "$(command -v brew)" ]; then
-  echo "Homebrew already installed — skipping install."
-  USE_HOMEBREW=true
-else
-  read -p "Homebrew is not installed. Would you like to install it? [y/N]: " install_brew
-  if [[ "$install_brew" =~ ^[Yy]$ ]]; then
-    echo "Installing Homebrew will allow us to manage and install essential development tools."
-    echo "You may be prompted for your password—this is required to install Homebrew and its packages system-wide."
+set -euo pipefail
 
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-    USE_HOMEBREW=true
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This dependency installer only supports macOS." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=.bin/lib/github-keys.sh
+source "$SCRIPT_DIR/../lib/github-keys.sh"
+
+install_homebrew() {
+  local installer
+  installer="$(mktemp "${TMPDIR:-/tmp}/homebrew-install.XXXXXX")"
+
+  if ! curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+    --max-time 60 https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh >"$installer"; then
+    rm -f "$installer"
+    return 1
+  fi
+
+  echo "Downloaded the official Homebrew installer. SHA-256:"
+  shasum -a 256 "$installer"
+  /bin/bash "$installer"
+  rm -f "$installer"
+}
+
+find_brew() {
+  if command -v brew >/dev/null 2>&1; then
+    command -v brew
+  elif [[ -x /opt/homebrew/bin/brew ]]; then
+    printf '%s\n' /opt/homebrew/bin/brew
+  elif [[ -x /usr/local/bin/brew ]]; then
+    printf '%s\n' /usr/local/bin/brew
   else
-    echo "Skipping Homebrew installation."
-    USE_HOMEBREW=false
+    return 1
+  fi
+}
+
+brew_bin=""
+if brew_bin="$(find_brew)"; then
+  echo "Homebrew already installed at $brew_bin."
+else
+  read -rp "Homebrew is not installed. Download and run its official installer? [y/N]: " install_brew
+  if [[ "$install_brew" =~ ^[Yy]$ ]]; then
+    command -v curl >/dev/null 2>&1 || {
+      echo "Missing dependency: curl" >&2
+      exit 1
+    }
+    install_homebrew
+    brew_bin="$(find_brew)" || {
+      echo "Homebrew installed, but its executable could not be found." >&2
+      exit 1
+    }
   fi
 fi
 
-# brew packages
-if [ "$USE_HOMEBREW" = true ]; then
-  brew install zsh chroma git fzf neovim starship neonctl kubectl helm minikube kubie bat eza zsh-autosuggestions zsh-syntax-highlighting
+if [[ -n "$brew_bin" ]]; then
+  eval "$("$brew_bin" shellenv)"
+  brew_packages=(
+    bat chroma curl eza ffmpeg fzf git helm jq kubectl kubie minikube neonctl
+    neovim pandoc qrencode rsync shellcheck starship tmux yt-dlp zsh
+    zsh-autosuggestions zsh-syntax-highlighting
+  )
+  "$brew_bin" install "${brew_packages[@]}"
+else
+  echo "Skipping Homebrew packages."
 fi
 
-# authorized_keys
-read -p "Would you like to set up authorized keys? [y/N]: " setup_keys
+read -rp "Would you like to replace authorized_keys with your GitHub public keys? [y/N]: " setup_keys
 if [[ "$setup_keys" =~ ^[Yy]$ ]]; then
-  read -p "Enter your GitHub username to fetch authorized keys: " github_username
-  if [ ! -f "$HOME/.ssh/authorized_keys" ]; then
-    mkdir -p "$HOME/.ssh"
-    curl "https://github.com/${github_username}.keys" > "$HOME/.ssh/authorized_keys"
-    echo "Authorized Keys Set Up"
-    cat "$HOME/.ssh/authorized_keys"
-  fi
+  read -rp "Enter your GitHub username: " github_username
+  fetch_github_keys "$github_username" "$HOME/.ssh/authorized_keys"
+  echo "Authorized keys updated with mode 0600."
 fi
 
-# oh-my-zsh
-if [ ! -d "$HOME/.oh-my-zsh" ]; then
-  git clone https://github.com/ohmyzsh/ohmyzsh.git ~/.oh-my-zsh
-
-  if [ ! -f "$HOME/.zshrc" ]; then
-    cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
-  fi
-
-  echo "Please restart your terminal or run 'exec zsh' to apply changes."
+if [[ ! -d "$HOME/.oh-my-zsh" ]]; then
+  command -v git >/dev/null 2>&1 || {
+    echo "Cannot install Oh My Zsh without git." >&2
+    exit 1
+  }
+  git clone --depth 1 https://github.com/ohmyzsh/ohmyzsh.git "$HOME/.oh-my-zsh"
+  echo "Oh My Zsh installed."
 fi
+
+echo "Dependency setup complete. Run 'exec zsh' to reload your shell."

--- a/.bin/macos/sync-flash-drive
+++ b/.bin/macos/sync-flash-drive
@@ -1,30 +1,68 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Function to rsync directories
-rsync_directories() {
-	source_path=$1
-	destination_path=$2
+set -euo pipefail
+umask 077
 
-	mkdir -p "$destination_path" && rsync -avz --exclude-from="$HOME/.gitignore_global" --progress --delete "$source_path" "$destination_path"
+if [[ "$(uname -s)" != "Darwin" ]]; then
+	echo "sync-flash-drive requires macOS." >&2
+	exit 1
+fi
+
+dry_run=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+	dry_run=true
+	shift
+fi
+if [[ $# -ne 0 ]]; then
+	echo "usage: $(basename "$0") [--dry-run]" >&2
+	exit 2
+fi
+
+command -v rsync >/dev/null 2>&1 || {
+	echo "Missing dependency: rsync" >&2
+	exit 1
 }
 
-# Check if the volume "Secure" is mounted
-if mount | grep -q "/Volumes/Secure"; then
-	echo "USB flash drive 'Secure' is mounted."
-	echo "Syncing files..."
+is_mounted() {
+	mount | awk -v path="$1" '$0 ~ " on " path " \\(" { found = 1 } END { exit !found }'
+}
 
-	# Sync Development folder to flash drive
-	rsync_directories "$HOME/Developer/projects/github/overtfuture" "/Volumes/Secure/Nate/Developer/projects/github/overtfuture"
-	rsync_directories "$HOME/Developer/projects/github/studioember" "/Volumes/Secure/Nate/Developer/projects/github/studioember"
-	rsync_directories "$HOME/Developer/projects/github/eventsheet" "/Volumes/Secure/Nate/Developer/projects/github/eventsheet"
+rsync_directories() {
+	local source_path="$1"
+	local destination_path="$2"
+	local args=(-a --human-readable --progress --delete)
 
-	# Sync $HOME folders to flash drive
-	rsync_directories "$HOME/.ssh/" "/Volumes/Secure/Nate/.ssh"
-
-	# Sync Travel folder to flash drive
-	if mount | grep -q "/Volumes/Personal-Drive"; then
-		rsync_directories "/Volumes/Personal-Drive/Travel" "/Volumes/Secure/Travel"
+	if [[ ! -d "$source_path" ]]; then
+		echo "Skipping missing source: $source_path" >&2
+		return
 	fi
-else
-	echo "Volume 'Secure' is not mounted."
+	if [[ "$dry_run" == true ]]; then
+		args+=(--dry-run)
+	fi
+	if [[ -f "$HOME/.gitignore_global" ]]; then
+		args+=(--exclude-from="$HOME/.gitignore_global")
+	fi
+
+	mkdir -p "$destination_path"
+	rsync "${args[@]}" "${source_path%/}/" "${destination_path%/}/"
+}
+
+if ! is_mounted /Volumes/Secure; then
+	echo "Volume 'Secure' is not mounted." >&2
+	exit 1
+fi
+
+if [[ "$dry_run" == false ]]; then
+	echo "This mirror sync deletes destination files that are absent from the source."
+	read -rp "Continue? [y/N]: " confirm
+	[[ "$confirm" =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
+fi
+
+rsync_directories "$HOME/Developer/projects/github/overtfuture" "/Volumes/Secure/Nate/Developer/projects/github/overtfuture"
+rsync_directories "$HOME/Developer/projects/github/studioember" "/Volumes/Secure/Nate/Developer/projects/github/studioember"
+rsync_directories "$HOME/Developer/projects/github/eventsheet" "/Volumes/Secure/Nate/Developer/projects/github/eventsheet"
+rsync_directories "$HOME/.ssh" "/Volumes/Secure/Nate/.ssh"
+
+if is_mounted /Volumes/Personal-Drive; then
+	rsync_directories "/Volumes/Personal-Drive/Travel" "/Volumes/Secure/Travel"
 fi

--- a/.bin/macos/usb-storage
+++ b/.bin/macos/usb-storage
@@ -1,6 +1,40 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Connects to Blaustahl Storage Device
-# See https://github.com/machdyne/blaustahl
+set -euo pipefail
 
-ls /dev/tty.usbmodem* && screen /dev/tty.usbmodem1234561
+if [[ "$(uname -s)" != "Darwin" ]]; then
+	echo "usb-storage requires macOS." >&2
+	exit 1
+fi
+
+command -v screen >/dev/null 2>&1 || {
+	echo "Missing dependency: screen" >&2
+	exit 1
+}
+
+device="${1:-}"
+if [[ $# -gt 1 ]]; then
+	echo "usage: $(basename "$0") [/dev/tty.usbmodem...]" >&2
+	exit 2
+fi
+
+if [[ -z "$device" ]]; then
+	devices=(/dev/tty.usbmodem*)
+	if [[ ! -e "${devices[0]}" ]]; then
+		echo "No USB modem device found." >&2
+		exit 1
+	fi
+	if [[ ${#devices[@]} -ne 1 ]]; then
+		echo "Multiple devices found; pass one explicitly:" >&2
+		printf '  %s\n' "${devices[@]}" >&2
+		exit 2
+	fi
+	device="${devices[0]}"
+fi
+
+if [[ ! "$device" == /dev/tty.usbmodem* || ! -e "$device" ]]; then
+	echo "Invalid USB modem device: $device" >&2
+	exit 2
+fi
+
+exec screen "$device"

--- a/.bin/setup-gitconfig
+++ b/.bin/setup-gitconfig
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
-#
-# This script sets up your global gitconfig on macOS using your SSH key for commit signing.
-# It will prompt you to enter your name and email, then use your SSH key (id_ed25519 or id_rsa)
-# for signing commits. Make sure you have at least one SSH key in ~/.ssh.
-#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=.bin/lib/github-keys.sh
+source "$SCRIPT_DIR/lib/github-keys.sh"
+
+command -v git >/dev/null 2>&1 || {
+	echo "Missing dependency: git" >&2
+	exit 1
+}
 
 # Prompt for user name and email
 read -rp "Enter your name: " user_name
 read -rp "Enter your email: " user_email
+
+if [[ -z "$user_name" || "$user_name" =~ [[:cntrl:]] ]]; then
+	echo "Name must not be empty or contain control characters." >&2
+	exit 2
+fi
+
+if [[ ! "$user_email" =~ ^[^[:space:]@]+@[^[:space:]@]+$ ]]; then
+	echo "Enter a valid email address." >&2
+	exit 2
+fi
 
 # Configure git with the provided details and SSH key for signing
 git config --global user.name "$user_name"
@@ -18,20 +34,15 @@ git config --global gpg.format ssh
 
 # Allowed signer keys
 echo "When using remote SSH and forwarding a local SSH agent, the local SSH key needs to be allowed for signing on the remote host"
-echo "This will curl your existing Github public keys to allow for git signing"
-read -p "Would you like to curl your Github public keys as allowed git commit signing keys? [y/N]: " setup_signing_keys
+echo "This can fetch your existing GitHub public keys to allow Git signature verification"
+read -rp "Would you like to fetch your GitHub public keys as allowed Git commit signing keys? [y/N]: " setup_signing_keys
 if [[ "$setup_signing_keys" =~ ^[Yy]$ ]]; then
-	read -p "Enter your GitHub username: " github_username
-	if [ ! -f "$HOME/.ssh/allowed_signers" ]; then
-		mkdir -p "$HOME/.ssh"
-		curl "https://github.com/${github_username}.keys" >"$HOME/.ssh/allowed_signers"
-		echo "Authorized Signing Keys Added"
-		cat "$HOME/.ssh/allowed_signers"
-		echo "Adding gpg signing with SSH keys"
-		git config --global gpg.ssh.defaultKeyCommand "ssh-add -L"
-		git config --global gpg.ssh.allowedSignersFile '$HOME/.ssh/allowed_signers'
-		git config --global commit.gpgsign true
-	fi
+	read -rp "Enter your GitHub username: " github_username
+	fetch_github_keys "$github_username" "$HOME/.ssh/allowed_signers" "$user_email"
+	echo "Allowed signing keys updated."
+	git config --global gpg.ssh.defaultKeyCommand "ssh-add -L"
+	git config --global gpg.ssh.allowedSignersFile "$HOME/.ssh/allowed_signers"
+	git config --global commit.gpgsign true
 fi
 
 # Sane defaults
@@ -54,12 +65,13 @@ if [ "$(uname)" = "Darwin" ]; then
 fi
 
 if [ -f "$HOME/.gitignore_global" ]; then
-	git config --global core.excludesfile ~/.gitignore_global
+	git config --global core.excludesfile "$HOME/.gitignore_global"
 fi
 
 echo "Git configuration updated:"
 echo "  user.name = $user_name"
 echo "  user.email = $user_email"
-echo "  Signing with SSH public keys from $HOME/.ssh/allowed_signers"
+if git config --global --get commit.gpgsign >/dev/null 2>&1; then
+	echo "  SSH commit signing = enabled"
+fi
 echo "------------------------------------"
-cat ~/.gitconfig

--- a/.bin/youtube
+++ b/.bin/youtube
@@ -13,14 +13,13 @@ need_cmd() {
 need_cmd yt-dlp
 need_cmd ffmpeg
 
-if [[ $# -lt 1 ]]; then
+if [[ $# -ne 1 ]]; then
 	err "usage: $(basename "$0") <video-url>"
 fi
 
 URL="$1"
 
 yt-dlp \
-	"$URL" \
 	-f "bv*+ba/b" \
 	--merge-output-format mp4 \
 	--embed-metadata \
@@ -34,4 +33,5 @@ yt-dlp \
 	--write-thumbnail \
 	--restrict-filenames \
 	--no-mtime \
-	-o "%(title)s.%(ext)s"
+	-o "%(title)s.%(ext)s" \
+	-- "$URL"

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,27 @@
+# Global development instructions
+
+## Implementation
+
+- Prefer simple, maintainable implementations.
+- Preserve each project's existing architecture and conventions.
+- Read the repository documentation before making changes.
+- Prefer Go for backend and systems work when the repository does not already dictate another language.
+- Prefer PostgreSQL for relational persistence.
+- For web applications, follow the framework already used by the repository. Do not replace an existing frontend stack without a clear reason.
+- Avoid unnecessary dependencies.
+
+## Scope and verification
+
+- Keep changes focused and reviewable.
+- Do not make unrelated cleanup changes.
+- Run relevant formatting, linting, tests, and builds before declaring work complete.
+- Clearly report commands that failed or could not be run.
+
+## Safety
+
+- Ask before destructive operations, breaking API changes, database resets, force pushes, or broad dependency upgrades.
+- Never commit secrets, credentials, `.env` files, access tokens, private keys, or generated local state.
+
+## Tools
+
+- Use `vi` as the preferred terminal editor when an editor must be selected.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,28 @@
+# Shared Codex defaults for macOS and GNU/Linux.
+# Keep model selection account-driven by omitting an explicit `model` value.
+
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "high"
+web_search = "live"
+
+project_doc_fallback_filenames = [
+  "CLAUDE.md",
+  "CONTRIBUTING.md",
+  "README.md",
+]
+
+project_doc_max_bytes = 65536
+
+[sandbox_workspace_write]
+network_access = true
+
+[history]
+persistence = "save-all"
+max_bytes = 104857600
+
+[mcp_servers.github]
+url = "https://api.githubcopilot.com/mcp/"
+bearer_token_env_var = "GITHUB_PAT_TOKEN"
+startup_timeout_sec = 20
+tool_timeout_sec = 120

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .DS_Store
 .bin/macos/youtube-dl
+.zshrc_secrets
+.env
+.env.*
+!.env.example
+.codex/*
+!.codex/config.toml
+!.codex/AGENTS.md

--- a/.zprofile
+++ b/.zprofile
@@ -1,8 +1,18 @@
-# Homebrew
-eval "$(/opt/homebrew/bin/brew shellenv)"
-# Homebrew zsh site functions
-FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+# Homebrew (Apple Silicon, Intel macOS, or Linuxbrew)
+if command -v brew >/dev/null 2>&1; then
+  eval "$(brew shellenv)"
+elif [[ -x /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -x /usr/local/bin/brew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+elif [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+
+if command -v brew >/dev/null 2>&1; then
+  FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+fi
 
 # Added by OrbStack: command-line tools and integration
 # This won't be added again if you remove it.
-source ~/.orbstack/shell/init.zsh 2>/dev/null || :
+[[ -r "$HOME/.orbstack/shell/init.zsh" ]] && source "$HOME/.orbstack/shell/init.zsh"

--- a/.zsh-tooling/docker
+++ b/.zsh-tooling/docker
@@ -1,5 +1,5 @@
 # Orbstack
 if [ -x "$(command -v orb)" ]; then
   eval "$(orbctl completion zsh)"
-  source $HOME/.orbstack/shell/init.zsh
+  [[ -r "$HOME/.orbstack/shell/init.zsh" ]] && source "$HOME/.orbstack/shell/init.zsh"
 fi

--- a/.zsh-tooling/gcloud
+++ b/.zsh-tooling/gcloud
@@ -1,5 +1,5 @@
 # The next line updates PATH for the Google Cloud SDK.
-if [ -f '/Users/Nate/Developer/libraries/google-cloud-sdk/path.zsh.inc' ]; then . '/Users/Nate/Developer/libraries/google-cloud-sdk/path.zsh.inc'; fi
+if [ -f "$HOME/Developer/libraries/google-cloud-sdk/path.zsh.inc" ]; then . "$HOME/Developer/libraries/google-cloud-sdk/path.zsh.inc"; fi
 
 # The next line enables shell command completion for gcloud.
-if [ -f '/Users/Nate/Developer/libraries/google-cloud-sdk/completion.zsh.inc' ]; then . '/Users/Nate/Developer/libraries/google-cloud-sdk/completion.zsh.inc'; fi
+if [ -f "$HOME/Developer/libraries/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/Developer/libraries/google-cloud-sdk/completion.zsh.inc"; fi

--- a/.zsh-tooling/golang
+++ b/.zsh-tooling/golang
@@ -1,23 +1,9 @@
 # GoLang
 if [ -x "$(command -v go)" ]; then
-  # OS Detection
-  if [[ `uname` == "Linux" ]]; then
-    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-    export GOROOT=/home/linuxbrew/.linuxbrew/opt/go/libexec
-  elif [[ `uname` == "Darwin" ]]; then
-    export GOROOT=/opt/homebrew/opt/go/libexec
-  else
-    echo 'Unknown OS!'
-  fi
-
   # Path Setup
-  export GOPATH=$HOME/Developer/libraries/go
-  export GOBIN=$GOPATH/bin
-  export PATH=$PATH:$GOPATH
-  export PATH=$PATH:$GOROOT/bin
-  export PATH=$GOBIN:$PATH
-
-  export GOPROXY=direct
+  export GOPATH="${GOPATH:-$HOME/Developer/libraries/go}"
+  export GOBIN="${GOBIN:-$GOPATH/bin}"
+  export PATH="$GOBIN:$PATH"
 
   # GoLang Private Modules
   export GOPRIVATE=github.com/studioember/*

--- a/.zsh-tooling/kubernetes
+++ b/.zsh-tooling/kubernetes
@@ -1,11 +1,13 @@
 # Kubernetes
-source <(kubectl completion zsh)
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion zsh)
+fi
 # krew
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
 # kubie
-if [ -f $HOME/.kube/kubie.zsh ]; then
-  source $HOME/.kube/kubie.zsh
+if [ -f "$HOME/.kube/kubie.zsh" ]; then
+  source "$HOME/.kube/kubie.zsh"
 fi
 
 # telepresence

--- a/.zsh-tooling/python
+++ b/.zsh-tooling/python
@@ -1,4 +1,4 @@
 # Python - Rye Management
 if [ -x "$(command -v rye)" ]; then
-    source "$HOME/.rye/env"
+    [[ -r "$HOME/.rye/env" ]] && source "$HOME/.rye/env"
 fi

--- a/.zshrc
+++ b/.zshrc
@@ -1,16 +1,22 @@
 export ZSH="$HOME/.oh-my-zsh"
+ZSH_DISABLE_COMPFIX=true
+
+# Oh My Zsh does not search Linuxbrew's fzf prefix automatically.
+if command -v brew >/dev/null 2>&1; then
+  if fzf_base="$(brew --prefix fzf 2>/dev/null)" && [[ -d "$fzf_base" ]]; then
+    export FZF_BASE="$fzf_base"
+  fi
+  unset fzf_base
+fi
 
 # Default Theme
 ZSH_THEME="imajes"
 
 # Plugins
 plugins=(
-  1password
-  brew
   colorize
   docker
   fnm
-  fzf
   git
   golang
   kubectl
@@ -19,26 +25,31 @@ plugins=(
   zsh-navigation-tools
 )
 
-# Source oh my zsh
-source $ZSH/oh-my-zsh.sh
-
-ZSH_DISABLE_COMPFIX=true
+command -v op >/dev/null 2>&1 && plugins+=(1password)
+command -v brew >/dev/null 2>&1 && plugins+=(brew)
 
 # zsh colorize
-ZSH_COLORIZE_TOOL=chroma
+if command -v chroma >/dev/null 2>&1; then
+  ZSH_COLORIZE_TOOL=chroma
+elif command -v pygmentize >/dev/null 2>&1; then
+  ZSH_COLORIZE_TOOL=pygmentize
+fi
 ZSH_COLORIZE_STYLE="colorful"
 ZSH_COLORIZE_CHROMA_FORMATTER=true-color
 
-# zsh-completions
-source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-
-# ZSH Highlighting
-if [[ `uname` == "Linux" ]]; then
-  source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-elif [[ `uname` == "Darwin" ]]; then
-  source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+# Source oh my zsh
+if [[ -r "$ZSH/oh-my-zsh.sh" ]]; then
+  source "$ZSH/oh-my-zsh.sh"
 else
-  echo 'Unknown OS!'
+  print -u2 "Oh My Zsh is not installed at $ZSH"
+fi
+
+# zsh autosuggestions
+if [[ -r /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]]; then
+  source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+elif command -v brew >/dev/null 2>&1 &&
+  [[ -r "$(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
+  source "$(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 fi
 
 # Basic Aliases
@@ -47,8 +58,8 @@ alias c="clear"
 # Tooling Configurations
 TOOLING_DIR="$HOME/.zsh-tooling"
 if [[ -d "$TOOLING_DIR" ]]; then
-  for tool in $TOOLING_DIR/*; do
-    source $tool
+  for tool in "$TOOLING_DIR"/*(.N); do
+    source "$tool"
   done
 fi
 
@@ -64,13 +75,22 @@ if [ -x "$(command -v eza)" ]; then
 fi
 
 # fzf, fuzzy finder
-if [ -x "$(command -v fzf)" ]; then 
-  source <(fzf --zsh)
+if [ -x "$(command -v fzf)" ]; then
+  if fzf_init="$(fzf --zsh 2>/dev/null)"; then
+    eval "$fzf_init"
+  elif [[ -r /usr/share/doc/fzf/examples/completion.zsh && -r /usr/share/doc/fzf/examples/key-bindings.zsh ]]; then
+    source /usr/share/doc/fzf/examples/completion.zsh
+    source /usr/share/doc/fzf/examples/key-bindings.zsh
+  elif [[ -n "${FZF_BASE:-}" && -r "$FZF_BASE/shell/completion.zsh" && -r "$FZF_BASE/shell/key-bindings.zsh" ]]; then
+    source "$FZF_BASE/shell/completion.zsh"
+    source "$FZF_BASE/shell/key-bindings.zsh"
+  fi
+  unset fzf_init
 
   # Set fzf theme to dracula and show file previews
   export FZF_DEFAULT_OPTS='
     --height 100% --layout=reverse
-    --preview "[ -f $(echo {} | awk '\''{print $NF}'\'') ] && bat --color=always --style=numbers $(echo {} | awk '\''{print $NF}'\'') || echo {}"
+    --preview "if [ -f {} ]; then bat --color=always --style=numbers -- {}; else printf '%s\\n' {}; fi"
     --preview-window=up:2:wrap
   '
   export FZF_CTRL_T_COMMAND='find $HOME/Developer -type f'
@@ -78,29 +98,46 @@ if [ -x "$(command -v fzf)" ]; then
 fi
 
 # QR Code Generator
-if [ -x "$(command -v qrencode)" ]; then 
-  alias qr='qrencode -m 2 -t utf8 <<< "$1"'
+if [ -x "$(command -v qrencode)" ]; then
+  qr() {
+    if [[ $# -ne 1 ]]; then
+      print -u2 'usage: qr <text>'
+      return 2
+    fi
+    printf '%s' "$1" | qrencode -m 2 -t utf8
+  }
 fi
 
 # Update Aliases for Linux and macOS
-if [[ `uname` == "Linux" ]]; then
-  if [ -x "$(command -v brew)" ]; then 
-    alias update="sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y && brew update && brew upgrade && brew autoremove && brew doctor"
-  else
-    alias update="sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y"
+update_system() {
+  if [[ "$(uname -s)" == "Linux" ]] && command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update && sudo apt-get upgrade && sudo apt-get autoremove
   fi
-elif [[ `uname` == "Darwin" ]]; then
-  alias update="brew update && brew upgrade -y && brew autoremove && brew doctor"
-else
-  echo 'Unknown OS!'
-fi
+  if command -v brew >/dev/null 2>&1; then
+    brew update && brew upgrade && brew autoremove && brew doctor
+  fi
+}
+alias update=update_system
 
 # Source private customization
-if [ -f ~/.zshrc_private ]; then
-  source ~/.zshrc_private
+if [ -f "$HOME/.zshrc_private" ]; then
+  source "$HOME/.zshrc_private"
 fi
 
-# Added by LM Studio CLI (lms)
-export PATH="$PATH:/Users/Nate/.lmstudio/bin"
-# End of LM Studio CLI section
+# Source secrets customization
+if [ -f "$HOME/.zshrc_secrets" ]; then
+  # Secret loaders should not announce variable names during every shell start.
+  source "$HOME/.zshrc_secrets" >/dev/null
+fi
 
+# Optional user-local tools
+[[ -d "$HOME/.lmstudio/bin" ]] && export PATH="$PATH:$HOME/.lmstudio/bin"
+export PATH="$HOME/.local/bin:$PATH"
+
+# Syntax highlighting must be sourced after all widgets and completions.
+if [[ -r /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
+  source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+elif command -v brew >/dev/null 2>&1 &&
+  [[ -r "$(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
+  source "$(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+fi

--- a/.zshrc_private
+++ b/.zshrc_private
@@ -4,27 +4,25 @@
 ZSH_THEME="dracula-pro"
 
 # iTerm
-test -e "$HOME/.iterm2_shell_integration.zsh" && source $HOME/.iterm2_shell_integration.zsh
+test -e "$HOME/.iterm2_shell_integration.zsh" && source "$HOME/.iterm2_shell_integration.zsh"
 
 # iOS Shellfish
 test -e "$HOME/.shellfishrc" && source "$HOME/.shellfishrc"
 
 # User placed binaries
-export PATH=$PATH:$HOME/.bin
-export PATH=$PATH:$HOME/.local/bin
+export PATH="$HOME/.local/bin:$HOME/.bin:$PATH"
 if [[ $(uname) == "Linux" ]]; then
-  export PATH=$PATH:$HOME/.bin/linux
+  export PATH="$HOME/.bin/linux:$PATH"
 elif [[ $(uname) == "Darwin" ]]; then
-  export PATH=$PATH:$HOME/.bin/macos
+  export PATH="$HOME/.bin/macos:$PATH"
 fi
 
 # usr/local/bin
-export PATH=$PATH:/usr/local/bin
+export PATH="/usr/local/bin:$PATH"
 
 # SSH
-if [[ $(uname) == "Linux" ]]; then
-  eval "$(ssh-agent -s)"
-  ssh-add ~/.ssh/id_ed25519
+if [[ $(uname) == "Linux" && -n "${SSH_AUTH_SOCK:-}" && -r "$HOME/.ssh/id_ed25519" ]]; then
+  ssh-add -l >/dev/null 2>&1 || ssh-add "$HOME/.ssh/id_ed25519"
 fi
 
 if [[ $(uname) == "Darwin" && -z "$SSH_CONNECTION" ]]; then
@@ -55,6 +53,6 @@ fi
 # Starship terminal
 if [ -x "$(command -v starship)" ]; then
   # Starship
-  export STARSHIP_CONFIG=$HOME/.config/starship/config.toml
+  export STARSHIP_CONFIG="$HOME/.config/starship/config.toml"
   eval "$(starship init zsh)"
 fi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Quick Start
 
-Clone and run the setup script:
+Clone and run the setup script on macOS or Debian-based Linux:
 
 ```shell
 git clone https://github.com/overtfuture/dotfiles.git
@@ -12,4 +12,49 @@ cd dotfiles
 # enjoy!
 ```
 
-The script presents a menu to run a full setup or individual steps (symlinks, dependencies, gitconfig, SSH config). Re-run it any time to add new symlinks or update configs — existing files are backed up before being replaced.
+The script presents a menu to run a full setup or individual steps:
+
+- Symlinks shared shell, tool, application, and Codex configuration while backing up existing files.
+- Dependencies use Homebrew on macOS and native `apt-get` packages on Debian, Ubuntu, and other Debian derivatives.
+- Git configuration optionally builds a correctly formatted SSH `allowed_signers` file from your public GitHub keys.
+- SSH server configuration is macOS-only and is validated with `sshd -t` before the script reports success.
+
+Re-run the installer any time to add new links or update configuration. The Debian installer does not add third-party package repositories; release-dependent packages such as `eza` and `starship` are installed only when the configured Debian repositories provide them.
+
+## Codex
+
+The shared Codex configuration installs these links while leaving credentials, sessions, logs, and other generated state local to each machine:
+
+```text
+~/.codex/config.toml -> <dotfiles>/.codex/config.toml
+~/.codex/AGENTS.md   -> <dotfiles>/.codex/AGENTS.md
+```
+
+Run the existing installer and choose **Codex config only**:
+
+```shell
+./install.sh
+```
+
+Existing destination files or incorrect symlinks are backed up with a timestamp before the shared files are linked. Running the installer again with the correct links already present is safe.
+
+The GitHub MCP server reads its bearer token from `GITHUB_PAT_TOKEN`; the token is not stored in this repository. For example, with the 1Password CLI:
+
+```shell
+export GITHUB_PAT_TOKEN="$(op read 'op://Private/GitHub Codex PAT/credential')"
+```
+
+If this dotfiles repository is public, configure that environment variable in a private or machine-local shell file such as `~/.zshrc_secrets`. Never add the token or the private shell file to version control.
+
+Verify the installation and start Codex:
+
+```shell
+codex --version
+codex
+```
+
+Then inspect MCP connections inside Codex:
+
+```text
+/mcp
+```

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -12,19 +12,37 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-info() { echo -e "  ${CYAN}${1}${NC}"; }
-success() { echo -e "  ${GREEN}✓ ${1}${NC}"; }
-warn() { echo -e "  ${YELLOW}⚠ ${1}${NC}"; }
-error() { echo -e "  ${RED}✗ ${1}${NC}"; }
-header() { echo -e "\n${BOLD}${1}${NC}"; }
+info() { printf '  %b%s%b\n' "$CYAN" "$1" "$NC"; }
+success() { printf '  %b✓ %s%b\n' "$GREEN" "$1" "$NC"; }
+warn() { printf '  %b⚠ %s%b\n' "$YELLOW" "$1" "$NC"; }
+error() { printf '  %b✗ %s%b\n' "$RED" "$1" "$NC" >&2; }
+header() { printf '\n%b%s%b\n' "$BOLD" "$1" "$NC"; }
 
-is_macos() { [[ "$(uname)" == "Darwin" ]]; }
+is_macos() { [[ "$(uname -s)" == "Darwin" ]]; }
 
-# Create a symlink, backing up any existing non-symlink file first.
+is_debian() {
+  [[ "$(uname -s)" == "Linux" ]] || return 1
+  [[ -r /etc/os-release ]] || return 1
+  grep -Eq '^ID="?debian"?$|^ID_LIKE="?([^" ]+ )*debian( [^" ]+)*"?$' /etc/os-release
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    error "Missing required command: $1"
+    return 1
+  }
+}
+
+# Create a symlink, backing up any existing destination first.
 # If a correct symlink already exists, skip it.
 symlink() {
   local src="$1"
   local dst="$2"
+
+  if [[ ! -e "$src" && ! -L "$src" ]]; then
+    error "Link source does not exist: $src"
+    return 1
+  fi
 
   # Already pointing to the right place — nothing to do
   if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
@@ -32,16 +50,12 @@ symlink() {
     return
   fi
 
-  # Existing real file/directory — back it up
-  if [ -e "$dst" ] && [ ! -L "$dst" ]; then
-    local bak="${dst}.bak.$(date +%Y%m%d%H%M%S)"
+  # Back up an existing file, directory, or incorrect/broken symlink.
+  if [[ -e "$dst" || -L "$dst" ]]; then
+    local bak
+    bak="${dst}.bak.$(date +%Y%m%d%H%M%S).$$"
     mv "$dst" "$bak"
     warn "Backed up: $dst → $bak"
-  fi
-
-  # Stale or wrong symlink — remove it
-  if [ -L "$dst" ]; then
-    rm "$dst"
   fi
 
   # Ensure parent directory exists
@@ -49,6 +63,23 @@ symlink() {
 
   ln -s "$src" "$dst"
   success "Linked: $dst → $src"
+}
+
+ensure_directory() {
+  local dir="$1"
+
+  if [[ -d "$dir" && ! -L "$dir" ]]; then
+    return
+  fi
+
+  if [[ -e "$dir" || -L "$dir" ]]; then
+    local bak
+    bak="${dir}.bak.$(date +%Y%m%d%H%M%S).$$"
+    mv "$dir" "$bak"
+    warn "Backed up: $dir → $bak"
+  fi
+
+  mkdir -p "$dir"
 }
 
 # ─── Sections ────────────────────────────────────────────────────────────────
@@ -63,12 +94,21 @@ setup_symlinks() {
   symlink "$DOTFILE_DIR/.zshrc_private" "$HOME/.zshrc_private"
   symlink "$DOTFILE_DIR/.bin" "$HOME/.bin"
 
+  setup_codex
+
   mkdir -p "$HOME/.config"
   symlink "$DOTFILE_DIR/.config/starship" "$HOME/.config/starship"
   symlink "$DOTFILE_DIR/.config/presenterm" "$HOME/.config/presenterm"
 
   setup_zsh_tooling
   setup_neovim
+}
+
+setup_codex() {
+  header "Codex configuration"
+  ensure_directory "$HOME/.codex"
+  symlink "$DOTFILE_DIR/.codex/config.toml" "$HOME/.codex/config.toml"
+  symlink "$DOTFILE_DIR/.codex/AGENTS.md" "$HOME/.codex/AGENTS.md"
 }
 
 setup_zsh_tooling() {
@@ -103,21 +143,18 @@ setup_zsh_tooling() {
     return
   fi
 
-  mkdir -p "$HOME/.zsh-tooling"
-
   if [[ "$selection" == "a" ]]; then
-    local dst="$HOME/.zsh-tooling"
-    if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$DOTFILE_DIR/.zsh-tooling" ]; then
-      info "Already linked: $dst"
-    else
-      [ -L "$dst" ] && rm "$dst"
-      ln -s "$DOTFILE_DIR/.zsh-tooling" "$dst"
-      success "Linked: $dst → $DOTFILE_DIR/.zsh-tooling"
-    fi
+    symlink "$DOTFILE_DIR/.zsh-tooling" "$HOME/.zsh-tooling"
     return
   fi
 
+  mkdir -p "$HOME/.zsh-tooling"
+
   for num in $selection; do
+    if [[ ! "$num" =~ ^[0-9]+$ ]]; then
+      warn "Invalid selection: $num"
+      continue
+    fi
     local idx=$((num - 1))
     if [ "$idx" -ge 0 ] && [ "$idx" -lt "${#tools[@]}" ]; then
       local tool="${tools[$idx]}"
@@ -131,13 +168,14 @@ setup_zsh_tooling() {
 setup_neovim() {
   header "Neovim config"
   local nvim_dir="$HOME/.config/nvim"
-  if [ -d "$nvim_dir" ]; then
+  if [[ -e "$nvim_dir" || -L "$nvim_dir" ]]; then
     info "Neovim config already exists at $nvim_dir — skipping"
     return
   fi
   read -r -p "  Clone lazyvim config to ~/.config/nvim? [y/N]: " confirm
   if [[ "$confirm" =~ ^[Yy]$ ]]; then
-    git clone https://github.com/overtfuture/lazyvim.git "$nvim_dir"
+    require_command git
+    git clone --depth 1 https://github.com/overtfuture/lazyvim.git "$nvim_dir"
     success "Neovim config cloned"
   else
     warn "Skipping Neovim config"
@@ -146,15 +184,18 @@ setup_neovim() {
 
 setup_dependencies() {
   header "Installing dependencies"
-  if ! is_macos; then
-    warn "Dependency setup is macOS-only — skipping"
-    return
+  if is_macos; then
+    "$DOTFILE_DIR/.bin/macos/setup-dependencies"
+  elif is_debian; then
+    "$DOTFILE_DIR/.bin/debian/setup-dependencies"
+  else
+    warn "Unsupported platform. Dependency setup supports macOS and Debian-based Linux."
   fi
-  "$DOTFILE_DIR/.bin/macos/setup-dependencies"
 }
 
 setup_gitconfig() {
   header "Git configuration"
+  require_command git
   "$DOTFILE_DIR/.bin/setup-gitconfig"
 }
 
@@ -172,8 +213,50 @@ setup_ssh() {
     return
   fi
 
-  sudo cp "$DOTFILE_DIR/sshd_conf.d/001-ssh-macos-security.conf" /etc/ssh/sshd_config.d/
-  sudo cp "$DOTFILE_DIR/sshd_conf.d/100-macos.conf" /etc/ssh/sshd_config.d/
+  require_command sudo
+  if [[ ! -x /usr/sbin/sshd ]]; then
+    error "Cannot validate SSH configuration: /usr/sbin/sshd is missing"
+    return 1
+  fi
+
+  local security_target=/etc/ssh/sshd_config.d/001-ssh-macos-security.conf
+  local macos_target=/etc/ssh/sshd_config.d/100-macos.conf
+  local security_backup="${security_target}.dotfiles-backup.$$"
+  local macos_backup="${macos_target}.dotfiles-backup.$$"
+  local had_security=false
+  local had_macos=false
+
+  sudo mkdir -p /etc/ssh/sshd_config.d
+  if sudo test -e "$security_target"; then
+    sudo cp -p "$security_target" "$security_backup"
+    had_security=true
+  fi
+  if sudo test -e "$macos_target"; then
+    sudo cp -p "$macos_target" "$macos_backup"
+    had_macos=true
+  fi
+
+  if ! sudo install -o root -g wheel -m 0644 \
+      "$DOTFILE_DIR/sshd_conf.d/001-ssh-macos-security.conf" "$security_target" ||
+    ! sudo install -o root -g wheel -m 0644 \
+      "$DOTFILE_DIR/sshd_conf.d/100-macos.conf" "$macos_target" ||
+    ! sudo /usr/sbin/sshd -t; then
+    if [[ "$had_security" == true ]]; then
+      sudo mv "$security_backup" "$security_target"
+    else
+      sudo rm -f "$security_target"
+    fi
+    if [[ "$had_macos" == true ]]; then
+      sudo mv "$macos_backup" "$macos_target"
+    else
+      sudo rm -f "$macos_target"
+    fi
+    error "SSH configuration was invalid; previous files were restored"
+    return 1
+  fi
+
+  [[ "$had_security" == false ]] || sudo rm -f "$security_backup"
+  [[ "$had_macos" == false ]] || sudo rm -f "$macos_backup"
   success "SSH configs deployed"
   warn "Restart sshd to apply: sudo launchctl stop com.openssh.sshd && sudo launchctl start com.openssh.sshd"
 }
@@ -181,14 +264,15 @@ setup_ssh() {
 # ─── Menu ─────────────────────────────────────────────────────────────────────
 
 print_menu() {
-  echo -e "\n${BOLD}Dotfiles Setup${NC}"
+  printf '\n%bDotfiles Setup%b\n' "$BOLD" "$NC"
   echo "────────────────"
   echo "  1) Full setup      (symlinks + dependencies + gitconfig + SSH)"
   echo "  2) Symlinks only"
-  echo "  3) Dependencies only"
-  echo "  4) Git config only"
-  echo "  5) SSH config only"
-  echo "  6) Exit"
+  echo "  3) Codex config only"
+  echo "  4) Dependencies only"
+  echo "  5) Git config only"
+  echo "  6) SSH config only (macOS)"
+  echo "  7) Exit"
   echo
 }
 
@@ -202,14 +286,15 @@ main() {
       setup_dependencies
       setup_gitconfig
       setup_ssh
-      echo -e "\n${GREEN}${BOLD}Done! Run 'exec zsh' to reload your shell.${NC}\n"
+      printf '\n%b%bDone! Run '\''exec zsh'\'' to reload your shell.%b\n\n' "$GREEN" "$BOLD" "$NC"
       break
       ;;
     2) setup_symlinks ;;
-    3) setup_dependencies ;;
-    4) setup_gitconfig ;;
-    5) setup_ssh ;;
-    6)
+    3) setup_codex ;;
+    4) setup_dependencies ;;
+    5) setup_gitconfig ;;
+    6) setup_ssh ;;
+    7)
       echo
       exit 0
       ;;
@@ -218,4 +303,6 @@ main() {
   done
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/sshd_conf.d/001-ssh-macos-security.conf
+++ b/sshd_conf.d/001-ssh-macos-security.conf
@@ -3,9 +3,10 @@ PubkeyAuthentication yes
 PasswordAuthentication no
 ChallengeResponseAuthentication no
 KbdInteractiveAuthentication no
+AuthenticationMethods publickey
 
-# Disable PAM (prevents password fallback)
-UsePAM no
+# PAM remains enabled by the macOS-specific defaults. Password and
+# keyboard-interactive authentication are disabled explicitly above.
 
 # Disallow root login over SSH for security
 PermitRootLogin no


### PR DESCRIPTION
## Summary

- add native Debian/Ubuntu dependency setup while retaining Homebrew support on macOS
- add portable shared Codex configuration and global development instructions with safe, idempotent linking
- harden GitHub SSH key handling, Git signing setup, macOS utilities, and SSH deployment
- remove machine-specific shell assumptions and make fzf, Go, Kubernetes, Homebrew, and Zsh initialization portable

## Why

The existing setup was primarily macOS-oriented, contained hardcoded machine paths, and skipped dependency installation on Debian-based systems. Several helpers also wrote downloaded keys without validation or restrictive permissions, interpolated clipboard data into AppleScript, or performed destructive synchronization without an explicit confirmation.

Codex configuration also contained machine-generated and absolute-path state, and the Oh My Zsh fzf plugin could not detect Linuxbrew installations.

## Impact

The existing menu-driven installer now supports macOS and Debian-based Linux, backs up replaced destinations, validates link sources, and offers a Codex-only setup path. Shared Codex files contain no model pin, credentials, tokens, machine-specific paths, or generated state. Existing Codex authentication, history, sessions, and caches remain local to each machine.

Shell startup now detects platform-specific tool layouts and initializes fzf directly without the Oh My Zsh installation-directory warning.

## Validation

- `bash -n` across all Bash scripts
- ShellCheck across all executable shell scripts
- `zsh -n` across Zsh configuration and tooling modules
- `git diff --check`
- TOML parsing and structural assertions for the shared Codex configuration
- secret-pattern scan across tracked and newly added files
- isolated Codex installer backup, symlink, idempotency, and whole-directory migration tests
- `codex mcp list` recognition of the GitHub hosted MCP configuration
- fresh interactive-shell fzf startup test

Package installation and privileged SSH deployment were not executed during validation.